### PR TITLE
AssessmentJS-getTableData.js-typo

### DIFF
--- a/AssessmentJS/getTableData.js
+++ b/AssessmentJS/getTableData.js
@@ -44,7 +44,7 @@ function getGarage() {
                     text: 'Structure/Walls',
                     style: 'tableText'
                 }, {
-                    text: StructureCheck,
+                    text: structureCheck,
                     noWrap: true,
                     style: 'tableText'
                 }, {


### PR DESCRIPTION
correct the typo ' structureCheck'  in AssessmentJS/getTableData.js