### PR TITLE
upload external pdf

### DIFF
--- a/ajax_uploadExternalPDF.php
+++ b/ajax_uploadExternalPDF.php
@@ -7,88 +7,58 @@
   $files = [];
   $booking = Array();
 
-  $bookingcode = SharedGetPostVar("bookingcode");
-  //error_log($bookingcode);
- 
-  // $fileName = $_POST['fileName'];
-  // $fileTmpName = $_POST['fileTmpName'];
-  // $fileSize = $_POST['fileSize'];
-  // $fileError = $_POST['fileError'];
-  // $fileType = $_POST['fileType'];
-  // error_log($fileName);
-  // error_log($fileTmpName);
-  // error_log($fileSize);
-  // error_log($fileError);
-  // error_log($fileType);
-  // if($fileError == 0)
-  //   {
-  //       if ($fileSize < 50000000)//50000kb == 50mb
-  //       {
-  //           $fileNameNew = "test.pdf";
-  //           $fileDestination = './pdfreport/'.$fileNameNew;
-  //           if(move_uploaded_file($fileTmpName,$fileDestination))
-  //           {
-  //             $rc = 0;
-  //             $msg = "Succeed";
-  //           }
-  //           else
-  //           {
-  //             $msg = 'faile';
-  //           }
-            
-  //       }
-  //       else
-  //       {
-  //           $rc = -1;
-  //           $msg = "Your file is too big";
-  //       }
-  //   }
-  //   else
-  //   {
-  //       $rc = -1;
-  //       $msg = "There was an error uploading this file";
-  //   }
-
+  //$bookingcode = SharedGetPostVar("bookingcode");
+  
   if (isset($_POST['submitPDF']))
   {
+    $bookingcode = $_POST['bookingcode'];
+    //error_log($bookingcode);
     $file = $_FILES['externalPDF'];
     $fileName = $file['name'];
     $fileTmpName = $file['tmp_name'];
     $fileSize = $file['size'];
     $fileError = $file['error'];
     $fileType = $file['type'];
-    error_log($fileName);
-    error_log($fileTmpName);
-    error_log($fileSize);
-    error_log($fileError);
-    error_log($fileType);
+    // error_log($fileName);
+    // error_log($fileTmpName);
+    // error_log($fileSize);
+    // error_log($fileError);
+    // error_log($fileType);
     if($fileError == 0)
     {
-        if ($fileSize < 500000)//50000kb == 50mb
+        if ($fileSize < 5000)//50000kb == 50mb
         {
-            $fileNameNew = uniqid('',true)."."."pdf";
+            $fileNameNew = $bookingcode."."."pdf";
             $fileDestination = './pdfreport/'.$fileNameNew;
             move_uploaded_file($fileTmpName,$fileDestination);
             $rc = 0;
             $msg = "Succeed";
+            echo "<script type='text/javascript'> 
+            var p = window.parent;
+            p.noty({text: 'Upload booking $bookingcode report successfully', type: 'success', timeout: 3000});
+            </script>";
         }
         else
         {
             $rc = -1;
             $msg = "Your file is too big";
+            echo "<script type='text/javascript'> 
+            var p = window.parent;
+            p.noty({text: 'The file is too big', type: 'error', timeout: 3000});
+            </script>";
         }
     }
     else
     {
         $rc = -1;
         $msg = "There was an error uploading this file";
+        echo "<script type='text/javascript'> 
+            var p = window.parent;
+            p.noty({text: 'There was an error uploading this file', type: 'error', timeout: 3000});
+            </script>";
     }
   }
   
 $response = array("rc" => $rc, "msg" => $msg,"passingText" => $passingText);
 $json = json_encode($response);
-echo $json;
-// header("Location:index.php");
-// exit;
-
 ?>

--- a/member.php
+++ b/member.php
@@ -1853,6 +1853,8 @@
         function(row,index)
         {
           //noty({text:'Select booking ' + row.bookingcode,type: 'warning', timeout: 4000});
+          //$bookingcode = row.bookingcode;
+          document.getElementById('pdfUploadBookingcode').value = row.bookingcode;
           $.post
           (
             'ajax_checkPDF.php',
@@ -1892,6 +1894,11 @@
         }
       ))
       noty({text: 'Please select a booking', type: 'warning', timeout: 2000});
+    }
+
+    function pdfUploadInput()
+    {
+      document.getElementById('pdfUploadButton').click();
     }
 
     function doMemberChangePassword()
@@ -2257,10 +2264,6 @@
 
     // ************************************************************************************************************
     // Document ready...
-    $(function()
-    {
-    });
-
     $(document).ready(function()
     {
       $.noty.defaults =
@@ -2303,37 +2306,6 @@
         }
       );
 
-      $('#uploadPDF').change(function(){
-        document.getElementById('pdfUploadButton').click();
-        $.post(
-          'ajax_uploadExternalPDF.php',
-          {
-            fileTmpName:'<?php echo $_FILES['externalPDF']['tmp_name']; ?>',
-            fileName:'<?php echo $_FILES['externalPDF']['name'] ?>',
-            fileSize:'<?php echo $_FILES['externalPDF']['size'] ?>',
-            fileError:'<?php echo $_FILES['externalPDF']['error'] ?>',
-            fileType:'<?php echo $_FILES['externalPDF']['type'] ?>'
-          },
-          function(result)
-            {
-              var response = JSON.parse(result);
-              if(response.rc == 0)
-              {
-                //this booking does not have a pdf in the ./pdf directory, could upload straght away
-                //noty({text:response.msg,type:'info',timeout:4000});
-                console.log("ok");
-                console.log(response.msg);
-              }
-              else
-              {
-                //This booking has a pdf in the ./pdf drectory, need to ask permission
-                console.log("'sth wrong'"); 
-                console.log(response.msg);
-                //noty({text:response.msg,type:'info',timeout:4000});
-              }
-            }
-        )
-      })
       
       $('#divBookingsG').datagrid
       (
@@ -2699,6 +2671,14 @@
   </script>
 </head>
 <body>
+  <!-- ********************************* ************************************************************************************************************************************-->
+  <!-- The upload external PDF button -->
+  <iframe name="pdfUpload" style="display:none" src=""></iframe>  
+  <form enctype="multipart/form-data" id="uploadPDF_Form" method="POST" action="ajax_uploadExternalPDF.php" target="pdfUpload">
+    <input type="file" id="uploadPDF" name="externalPDF" accept="application/pdf,application/vnd.ms-excel" onchange="pdfUploadInput()"/>
+    <input type="text" name="bookingcode" value="" id="pdfUploadBookingcode"/>
+    <input id="pdfUploadButton" type="submit" name="submitPDF">Submit</button>
+  </form>
   <!-- *********************************************************************************************************************************************************************** -->
   <!-- Toolbars...                                                                                                                                                              -->
   <div id="tbBookings" style="height: auto; display: none">
@@ -2755,10 +2735,6 @@
     </div>
   </div>
 
-  <form enctype="multipart/form-data" id="uploadPDF_Form" method="POST" action="ajax_uploadExternalPDF.php">
-    <input type="file" id="uploadPDF" name="externalPDF" accept="application/pdf,application/vnd.ms-excel">
-    <button id="pdfUploadButton" type="submit" name="submitPDF">Submit</button>
-  </form>
   <!-- *********************************************************************************************************************************************************************** -->
   <!-- Reports...                                                                                                                                                              -->
   <div id="dlgNumReporsByType" class="easyui-dialog" title="#Reports by Type" style="width: 800px; height: 600px;" data-options="resizable: false, modal: false, closable: false, closed: true">


### PR DESCRIPTION
the architect could upload external pdf to the server. 
1. the report can be overwritten, upload is fine. 
2. message will display accordingly. 
3. upload stays in the same member.php, do not need to redirect back. 
4. booking code can pass successfully. I get the booking code when the user hit the ‘upload PDF report’ button, and store it inside the <form>, so when submit, this value can post together. 