### PR TITLE
safari on iOS open pdf report, "upload PDF report " button

### DIFF
--- a/AdviceJS/PDFGenerator.js
+++ b/AdviceJS/PDFGenerator.js
@@ -4,6 +4,7 @@
 
 /**
  * Core function of the PDF generator
+ * detect Safari on iOS learn from http://jsfiddle.net/jlubean/dL5cLjxt/ 
  * */
 function generatePDF(mode) {
     // Page start drawing from here...

--- a/AssessmentJS/PDFGenerator.js
+++ b/AssessmentJS/PDFGenerator.js
@@ -4,6 +4,7 @@
 
 /**
  * Core function of the PDF generator
+ * detect Safari on iOS learn from http://jsfiddle.net/jlubean/dL5cLjxt/ 
  * */
 function generatePDF(mode) {
     // Page start drawing from here...

--- a/CommercialPropertyJS/PDFGenerator.js
+++ b/CommercialPropertyJS/PDFGenerator.js
@@ -4,6 +4,7 @@
 
 /**
  * Core function of the PDF generator
+ * detect Safari on iOS learn from http://jsfiddle.net/jlubean/dL5cLjxt/ 
  * */
 function generateCommercialPropertyPDF(mode) {
     //reset image number and general notes paragraphs number
@@ -13,6 +14,8 @@ function generateCommercialPropertyPDF(mode) {
         $('#savingPDFAlert').show('fade');
     }
     resetTotalCounting();
+    var isSafari = !!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/);
+    var iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 
     var isMobile = {
         Android: function() {
@@ -1154,15 +1157,24 @@ function generateCommercialPropertyPDF(mode) {
     {
         if( isMobile.any() )
         {
-            var reader = new FileReader();
+            if (isSafari && iOS) 
+            {
+                //alert("You are using Safari on iOS!");
+                pdfMake.createPdf(docDefinition).open();
+            }
+            else
+            {
+                var reader = new FileReader();
 
-            pdfMake.createPdf(docDefinition).getBlob(function(blob){
-                reader.onload = function(e){
-                    //window.location.href = reader.result;
-                    window.open(reader.result,'_blank');
-                };
-                reader.readAsDataURL(blob);
-            });
+                pdfMake.createPdf(docDefinition).getBlob(function(blob){
+                    reader.onload = function(e){
+                        //window.location.href = reader.result;
+                        window.open(reader.result,'_blank');
+                    };
+                    reader.readAsDataURL(blob);
+                });
+            }
+          
         }
         else
         {

--- a/ConstructionJS/PDFGenerator.js
+++ b/ConstructionJS/PDFGenerator.js
@@ -4,6 +4,7 @@
 
 /**
  * Core function of the PDF generator
+ * detect Safari on iOS learn from http://jsfiddle.net/jlubean/dL5cLjxt/ 
  * */
 function generatePDF(mode) {
     resetImageCounting();

--- a/DesignConsultationJS/PDFGenerator.js
+++ b/DesignConsultationJS/PDFGenerator.js
@@ -4,6 +4,7 @@
 
 /**
  * Core function of the PDF generator
+ * detect Safari on iOS learn from http://jsfiddle.net/jlubean/dL5cLjxt/ 
  * */
 
 

--- a/DilapidationJS/PDFGenerator.js
+++ b/DilapidationJS/PDFGenerator.js
@@ -1,5 +1,6 @@
 /**
- * Created by TengShinan on 24/10/17.
+ * Created by Fafa on 24/10/17.
+ * detect Safari on iOS learn from http://jsfiddle.net/jlubean/dL5cLjxt/ 
  */
 
 function generatePDF(mode) {

--- a/HOWJS/PDFGenerator.js
+++ b/HOWJS/PDFGenerator.js
@@ -4,9 +4,12 @@
 
 /**
  * Core function of the PDF generator
+ * detect Safari on iOS learn from http://jsfiddle.net/jlubean/dL5cLjxt/ 
  * */
 function generateHOWPDF(mode) {
     resetTotalImagesCaptions();
+    var isSafari = !!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/);
+    var iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
     if (mode == 'save')
     {
         $('#savingPDFAlert').show('fade');
@@ -789,15 +792,24 @@ function generateHOWPDF(mode) {
     {
         if( isMobile.any() )
         {
-            var reader = new FileReader();
+            if (isSafari && iOS) 
+            {
+                //alert("You are using Safari on iOS!");
+                pdfMake.createPdf(docDefinition).open();
+            }
+            else
+            {
+                var reader = new FileReader();
 
-            pdfMake.createPdf(docDefinition).getBlob(function(blob){
-                reader.onload = function(e){
-                    //window.location.href = reader.result;
-                    window.open(reader.result,'_blank');
-                };
-                reader.readAsDataURL(blob);
-            });
+                pdfMake.createPdf(docDefinition).getBlob(function(blob){
+                    reader.onload = function(e){
+                        //window.location.href = reader.result;
+                        window.open(reader.result,'_blank');
+                    };
+                    reader.readAsDataURL(blob);
+                });
+            }
+            
         }
         else
         {

--- a/HomeFeasibilityJS/PDFGenerator.js
+++ b/HomeFeasibilityJS/PDFGenerator.js
@@ -4,6 +4,7 @@
 
 /**
  * Core function of the PDF generator
+ * detect Safari on iOS learn from http://jsfiddle.net/jlubean/dL5cLjxt/ 
  * */
 function generatePDF(mode) {
     // Page start drawing from here...

--- a/MaintenanceJS/PDFGenerator.js
+++ b/MaintenanceJS/PDFGenerator.js
@@ -1,5 +1,6 @@
 /**
- * Created by TengShinan on 10/10/17.
+ * Created by TengShinan,Fafa on 10/10/17.
+ * detect Safari on iOS learn from http://jsfiddle.net/jlubean/dL5cLjxt/ 
  */
 
 function generatePDF(mode) {

--- a/RenovationFeasibilityJS/PDFGenerator.js
+++ b/RenovationFeasibilityJS/PDFGenerator.js
@@ -4,6 +4,7 @@
 
 /**
  * Core function of the PDF generator
+ * detect Safari on iOS learn from http://jsfiddle.net/jlubean/dL5cLjxt/ 
  * */
 function generatePDF(mode) {
     var isSafari = !!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/);

--- a/TimberJS/PDFGenerator.js
+++ b/TimberJS/PDFGenerator.js
@@ -4,6 +4,7 @@
 
 /**
  * Core function of the PDF generator
+ * detect Safari on iOS learn from http://jsfiddle.net/jlubean/dL5cLjxt/ 
  * */
 function generatePDF(mode) {
     var isSafari = !!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/);

--- a/TimberReport.php
+++ b/TimberReport.php
@@ -4023,7 +4023,6 @@
     <button onclick="SaveReport()" type="button" class="btn btn-primary save">Save</button>
     <button onclick="generatePDF('final')" type="button" class="btn btn-primary">View as PDF</button>
     <button onclick="checkPDF()" type="button" class="btn btn-primary">Save as Report for Customer</button>
-    <button onclick="generatePDF('preview')" type="button" class="btn btn-primary">Preview PDF</button>
     <?php
         }
         else

--- a/member.php
+++ b/member.php
@@ -2781,8 +2781,8 @@
         if (SharedIsAdmin())
         {
       ?>
-          <a href="javascript:void(0)" onClick="doUploadReportPDF()" class="easyui-linkbutton" iconCls="icon-duplicate">Upload PDF Report</a>
           <a href="javascript:void(0)" onClick="doMarkPaid()" class="easyui-linkbutton" iconCls="icon-payment">Paid</a>
+          <a href="javascript:void(0)" onClick="doUploadReportPDF()" class="easyui-linkbutton" iconCls="icon-duplicate">Upload PDF Report</a>
           <a href="javascript:void(0)" onClick="doAssignMember()" class="easyui-linkbutton" iconCls="icon-man">Allocated Arch/Inspect</a>
           <a href="javascript:void(0)" onClick="doMarkUnCompleted()" class="easyui-linkbutton" iconCls="icon-redo">Redo</a>
           <a href="javascript:void(0)" onClick="doMarkApproved()" class="easyui-linkbutton" iconCls="icon-checkboxes">Approved</a>


### PR DESCRIPTION
1. create a new button to open the report HTML on safari on iOS, but then the report pdf could not open. Therefore, update the PDFGenerator.js in all the report, if it detects it is safari on iOS, will use an alternative method to open the pdf report. 
2. the "upload PDF report" button on the toolbar is updated to only visible to admin.
